### PR TITLE
Move around Chapters 6 and 7

### DIFF
--- a/ci/intro-to-cpp/index.html
+++ b/ci/intro-to-cpp/index.html
@@ -88,17 +88,17 @@
     <p>p. 169: Optional 12, 13</p>
     <p>For exercise 2, provide a working implementation with comments
     describing how each part was fixed.</p>
-    <h3 id="Chapter_6_-_Writing_a_Program">Chapter 6 - Writing a Program</h3>
-    <p>p. 217: Drill</p>
-    <p>p. 218: Exercises 4-6</p>
-    <h3 id="Chapter_7_-_Completing_a_Program">Chapter 7 - Completing a
-    Program</h3>
-    <p>Just read the chapter.</p>
     <h3 id="Chapter_8_-_Technicalities.3A_Functions.2C_etc.">Chapter 8 -
     Technicalities: Functions, etc.</h3>
     <p>Just read the chapter.</p>
     <h3 id="Chapter_9_-_Technicalities.3A_Classes.2C_etc.">Chapter 9 -
     Technicalities: Classes, etc.</h3>
+    <p>Just read the chapter.</p>
+    <h3 id="Chapter_6_-_Writing_a_Program">Chapter 6 - Writing a Program</h3>
+    <p>p. 217: Drill</p>
+    <p>p. 218: Exercises 4-6</p>
+    <h3 id="Chapter_7_-_Completing_a_Program">Chapter 7 - Completing a
+    Program</h3>
     <p>Just read the chapter.</p>
     <h3 id="Advanced">Advanced</h3>
     <p>Students wanting to cover more advanced topics of the C++ programming


### PR DESCRIPTION
Moves Chapters 6 and 7 to after Chapters 8 and 9. This way, students get to learn about functions and classes first before taking  on the calculator project, which requires some knowledge of both.